### PR TITLE
I_MPI_OFI_LIBRARY_INTERNAL is read during `module load impi`

### DIFF
--- a/apps/StarCCM/STARCCM_Submit_Server.sbatch
+++ b/apps/StarCCM/STARCCM_Submit_Server.sbatch
@@ -25,9 +25,9 @@
 # with libfabric in the install location that uses.
 
 
-module load intelmpi
 # Tell Intel MPI to use external libfabric version with:
 export I_MPI_OFI_LIBRARY_INTERNAL=0
+module load intelmpi
 export I_MPI_FABRICS=shm:ofi
 export I_MPI_OFI_PROVIDER=efa
 # This is to ensure the correct EFA fabrics are used.

--- a/apps/StarCCM/STARCCM_Submit_Simple.sbatch
+++ b/apps/StarCCM/STARCCM_Submit_Simple.sbatch
@@ -18,9 +18,9 @@
 # with libfabric in the install location that uses.
 
 
-module load intelmpi
 # Tell Intel MPI to use external libfabric version with:
 export I_MPI_OFI_LIBRARY_INTERNAL=0
+module load intelmpi
 export I_MPI_FABRICS=shm:ofi
 export I_MPI_OFI_PROVIDER=efa
 # This is to ensure the correct EFA fabrics are used.

--- a/apps/StarCCM/gpu/STARCCM_GPGPU_Submit.sbatch
+++ b/apps/StarCCM/gpu/STARCCM_GPGPU_Submit.sbatch
@@ -22,9 +22,9 @@
 # with libfabric in the install location that uses.
 
 
-module load intelmpi
 # Tell Intel MPI to use external libfabric version with:
 export I_MPI_OFI_LIBRARY_INTERNAL=0
+module load intelmpi
 export I_MPI_FABRICS=shm:ofi
 export I_MPI_OFI_PROVIDER=efa
 # This is to ensure the correct EFA fabrics are used.


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
