### PR TITLE
[Utils/IOR] Add IOR parallel I/O storage benchmark

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ This repo is maintained by AWS HPC Solution Architects, who will take care of up
 2. [OSU Micro-Benchmarks](https://github.com/aws-samples/hpc-applications/tree/main/Utils/OSU-Benchmarks) - MPI latency, bandwidth, and collective performance benchmarks
 3. [HPL (High Performance Linpack)](https://github.com/aws-samples/hpc-applications/tree/main/Utils/HPL) - Floating-point compute benchmark (TOP500), optimised for hpc8a with AOCC and AOCL BLIS
 4. [GPU Microbenchmarks](https://github.com/aws-samples/hpc-applications/tree/main/Utils/GPU-Benchmarks) - NCCL, NVSHMEM, and OSU MPI benchmarks for GPU clusters (p5/p5en) using the NVIDIA HPC Benchmarks container over EFA
+5. [IOR](https://github.com/aws-samples/hpc-applications/tree/main/Utils/IOR) - Parallel filesystem / storage I/O benchmark (aggregate throughput and metadata), with Amazon FSx for Lustre tuning
 
 ## HPC tuning and configuration guides:
 1. [Flexible Cores Configuration](https://github.com/aws-samples/hpc-applications/tree/main/Utils/flexible-cores) - Examples for configuring flexible core counts on Hpc7a and Hpc8a instances using Intel MPI and OpenMPI, including explicit core pinning strategies

--- a/Utils/IOR/README.md
+++ b/Utils/IOR/README.md
@@ -1,0 +1,111 @@
+# IOR — Parallel I/O Benchmark
+
+[IOR](https://github.com/hpc/ior) (Interleaved or Random) is the de-facto standard benchmark for parallel filesystems. It uses MPI to coordinate many processes that read and write a dataset in parallel, and reports the **aggregate throughput** (MiB/s) and IOPS. On AWS it is the right tool to characterise **Amazon FSx for Lustre** (and other shared filesystems such as Amazon EFS or a self-managed parallel filesystem).
+
+The repository also bundles **mdtest**, which measures **metadata** performance — file/directory create, stat, and remove rates — which is often the limiting factor for workloads with many small files.
+
+- Project homepage / docs: <https://ior.readthedocs.io/en/latest/>
+- Source: <https://github.com/hpc/ior>
+- Summary slides (LLNL): <https://asc.llnl.gov/sites/asc/files/2020-06/IOR_Summary_v1.0.pdf>
+- Lustre tuning wiki: <https://wiki.lustre.org/IOR>
+
+## What it measures
+
+| Pattern | IOR flag | What it tells you |
+|---------|----------|-------------------|
+| File-per-process (fpp) | `-F` | Peak aggregate bandwidth — each rank owns its own file, the easiest case for Lustre to stripe and the usual headline number |
+| Single-shared-file (ssf) | *(no `-F`)* | Shared-file bandwidth — all ranks write one file; stresses OST striping and shared-file locking |
+| Sequential vs random | `-z` | Large sequential transfers (default) vs random offsets |
+| Metadata (mdtest) | n/a | File/dir create, stat, and remove operations per second |
+
+## Build
+
+Two build scripts are provided — one per MPI stack, mirroring the OSU and HPL utilities in this repo. Both download the official IOR **4.0.0** release tarball (which ships a pre-generated `configure`, so no autotools step is needed), compile the POSIX and MPI-IO back-ends, and install `ior` and `mdtest` to the shared filesystem.
+
+**OpenMPI** (the default AWS EFA stack):
+
+```bash
+bash build_ior_openmpi.sh      # → /fsx/IOR-OpenMPI/install/bin/{ior,mdtest}
+```
+
+**Intel MPI:**
+
+```bash
+bash build_ior_intelmpi.sh     # → /fsx/IOR-IntelMPI/install/bin/{ior,mdtest}
+```
+
+To build a different release, override `IOR_VERSION` at the top of the script.
+
+## Run
+
+The launcher [`ior.sbatch`](ior.sbatch) is fully parametric — every IOR and filesystem setting is an environment variable with a sensible default:
+
+```bash
+# Defaults: OpenMPI, POSIX, file-per-process, 2 nodes, 12 ranks/node
+sbatch ior.sbatch
+
+# Single shared file, MPI-IO back-end, 4 MiB transfers
+IOR_FILEMODE=ssf IOR_API=MPIIO IOR_TRANSFER=4m sbatch ior.sbatch
+
+# Scale out to 8 nodes and push more ranks per node
+sbatch -N 8 --export=ALL,IOR_TASKS_PER_NODE=16 ior.sbatch
+
+# Use Intel MPI
+IOR_MPI=intelmpi sbatch ior.sbatch
+
+# Also run the mdtest metadata benchmark
+IOR_MDTEST=1 sbatch ior.sbatch
+```
+
+### Environment variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `IOR_MPI` | `openmpi` | MPI stack / install to use: `openmpi` or `intelmpi` |
+| `IOR_API` | `POSIX` | I/O back-end: `POSIX` or `MPIIO` |
+| `IOR_FILEMODE` | `fpp` | `fpp` (file-per-process) or `ssf` (single shared file) |
+| `IOR_BLOCK` | `4g` | Per-task block size (`-b`). Aggregate data = ranks × block × segments |
+| `IOR_TRANSFER` | `1m` | Size of each read/write call (`-t`). 1–16 MiB is the Lustre sweet spot |
+| `IOR_SEGMENTS` | `1` | Segments per task (`-s`) |
+| `IOR_ITER` | `3` | Iterations / repetitions (`-i`) |
+| `IOR_TASKS_PER_NODE` | `12` | MPI ranks per node. I/O saturates well before all cores; 8–16 is typical |
+| `IOR_DIR` | `/fsx/ior-test` | Test directory on the shared filesystem |
+| `IOR_STRIPE_COUNT` | `-1` | Lustre stripe count (`-1` = all OSTs) applied to `IOR_DIR` |
+| `IOR_STRIPE_SIZE` | `1M` | Lustre stripe size applied to `IOR_DIR` |
+| `IOR_MDTEST` | `0` | Set to `1` to also run the mdtest metadata benchmark |
+| `IOR_EXTRA` | *(empty)* | Extra arguments appended to the `ior` command line |
+
+The number of nodes and the partition/constraint come from the usual SBATCH directives (`-N`, `--partition`, `--constraint`); edit the defaults at the top of `ior.sbatch` for your cluster.
+
+## Amazon FSx for Lustre best practices
+
+These are baked into `ior.sbatch` and worth understanding when interpreting results:
+
+1. **Stripe the test directory across all OSTs.** The launcher runs `lfs setstripe -c -1 -S 1M` on `IOR_DIR` so every file created under it is spread across all Object Storage Targets. Without striping, a single-shared-file test is bottlenecked on one OST. Match `IOR_STRIPE_COUNT` to your filesystem's OST count.
+2. **Size the dataset to defeat the client cache.** Each FSx for Lustre client caches data in node RAM. The launcher (a) drops the page cache on every node before the read phase, and (b) passes `-C` so each rank reads a file written by a *different* node. For a fully cache-immune read, also make the aggregate dataset (ranks × block × segments) larger than the total client RAM.
+3. **Use large transfers.** `-t 1m` (up to `4m`–`16m`) aligns with Lustre RPC sizes and amortises per-call overhead. Tiny transfers measure latency, not bandwidth.
+4. **`fsync` after write (`-e`).** Ensures written data reaches the filesystem rather than sitting in the client cache, so the reported write bandwidth is real.
+5. **Right-size ranks per node.** Storage bandwidth (and the EFA/network path to FSx) saturates well before you use every core; 8–16 ranks/node is usually optimal. More ranks add contention without more throughput.
+6. **Provision the filesystem for the test.** FSx for Lustre throughput scales with provisioned capacity and the per-TiB throughput tier. A small filesystem will cap aggregate bandwidth regardless of how many clients you add.
+
+## Metrics
+
+IOR prints a summary table at the end of the run. The headline numbers are:
+
+```
+Operation   Max(MiB)   Min(MiB)  Mean(MiB) ...
+write        12345.6     ...
+read         23456.7     ...
+```
+
+- **`Max Write` / `Max Read` (MiB/s)** — aggregate throughput across all ranks. The primary result.
+- **IOPS** — reported when transfers are small; relevant for small-I/O workloads.
+- **mdtest** (when `IOR_MDTEST=1`) reports **creates/sec, stats/sec, removes/sec** for files and directories.
+
+## Files
+
+| File | Description |
+|------|-------------|
+| `build_ior_openmpi.sh` | Download and build IOR + mdtest 4.0.0 against OpenMPI → `/fsx/IOR-OpenMPI/install` |
+| `build_ior_intelmpi.sh` | Download and build IOR + mdtest 4.0.0 against Intel MPI → `/fsx/IOR-IntelMPI/install` |
+| `ior.sbatch` | Parametric Slurm launcher — write/read throughput with Lustre striping, page-cache dropping, and an optional mdtest metadata run |

--- a/Utils/IOR/build_ior_intelmpi.sh
+++ b/Utils/IOR/build_ior_intelmpi.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+# Build the IOR + mdtest parallel I/O benchmarks against Intel MPI.
+#
+# IOR (https://github.com/hpc/ior) measures parallel-filesystem throughput
+# (POSIX and MPI-IO back-ends) and the bundled mdtest measures metadata
+# performance. The official release tarball ships a pre-generated ./configure,
+# so no autotools/bootstrap step is required.
+set -e
+
+module load intelmpi
+module load libfabric-aws
+
+IOR_VERSION="4.0.0"
+IOR_URL="https://github.com/hpc/ior/releases/download/${IOR_VERSION}/ior-${IOR_VERSION}.tar.gz"
+INSTALL_DIR="/fsx/IOR-IntelMPI"
+TARBALL="/tmp/ior-${IOR_VERSION}.tar.gz"
+
+echo "==> Downloading IOR ${IOR_VERSION}..."
+wget -q -O "$TARBALL" "$IOR_URL"
+
+echo "==> Extracting to ${INSTALL_DIR}..."
+mkdir -p "$INSTALL_DIR"
+tar xzf "$TARBALL" -C "$INSTALL_DIR" --strip-components=1
+
+echo "==> Configuring (POSIX + MPI-IO back-ends via mpicc)..."
+cd "$INSTALL_DIR"
+./configure MPICC=mpicc --prefix="$INSTALL_DIR/install" > configure.log 2>&1
+
+echo "==> Compiling..."
+make -j"$(nproc)" > build.log 2>&1
+
+echo "==> Installing..."
+make install > install.log 2>&1
+
+echo "==> Done. Binaries installed to ${INSTALL_DIR}/install/bin"
+echo "    ior:    ${INSTALL_DIR}/install/bin/ior"
+echo "    mdtest: ${INSTALL_DIR}/install/bin/mdtest"

--- a/Utils/IOR/build_ior_openmpi.sh
+++ b/Utils/IOR/build_ior_openmpi.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+# Build the IOR + mdtest parallel I/O benchmarks against OpenMPI.
+#
+# IOR (https://github.com/hpc/ior) measures parallel-filesystem throughput
+# (POSIX and MPI-IO back-ends) and the bundled mdtest measures metadata
+# performance (file/dir create, stat, remove rates). On AWS these are the
+# standard tools for characterising Amazon FSx for Lustre.
+#
+# The official release tarball ships a pre-generated ./configure, so no
+# autotools/bootstrap step is required.
+set -e
+
+IOR_VERSION="4.0.0"
+IOR_URL="https://github.com/hpc/ior/releases/download/${IOR_VERSION}/ior-${IOR_VERSION}.tar.gz"
+INSTALL_DIR="/fsx/IOR-OpenMPI"
+TARBALL="/tmp/ior-${IOR_VERSION}.tar.gz"
+
+module load openmpi
+module load libfabric-aws
+
+echo "==> Downloading IOR ${IOR_VERSION}..."
+wget -q -O "$TARBALL" "$IOR_URL"
+
+echo "==> Extracting to ${INSTALL_DIR}..."
+mkdir -p "$INSTALL_DIR"
+tar xzf "$TARBALL" -C "$INSTALL_DIR" --strip-components=1
+
+echo "==> Configuring (POSIX + MPI-IO back-ends via mpicc)..."
+cd "$INSTALL_DIR"
+./configure MPICC=mpicc --prefix="$INSTALL_DIR/install" > configure.log 2>&1
+
+echo "==> Compiling..."
+make -j"$(nproc)" > build.log 2>&1
+
+echo "==> Installing..."
+make install > install.log 2>&1
+
+echo "==> Done. Binaries installed to ${INSTALL_DIR}/install/bin"
+echo "    ior:    ${INSTALL_DIR}/install/bin/ior"
+echo "    mdtest: ${INSTALL_DIR}/install/bin/mdtest"
+echo "    Example: mpirun -np 16 ${INSTALL_DIR}/install/bin/ior -a POSIX -b 4g -t 1m -F -e -C -w -r -o /fsx/ior-test/f"

--- a/Utils/IOR/ior.sbatch
+++ b/Utils/IOR/ior.sbatch
@@ -1,0 +1,152 @@
+#!/bin/bash
+#SBATCH --job-name=ior
+#SBATCH --constraint=hpc8a.96xlarge
+#SBATCH --partition=hpc8a
+#SBATCH --nodes=2
+#SBATCH --exclusive
+#SBATCH --output=ior-%j.out
+#
+# Parametric IOR launcher for parallel-filesystem (Amazon FSx for Lustre)
+# throughput benchmarking. One script for all configurations — everything is
+# controlled via environment variables with sensible defaults.
+#
+# IOR writes then reads a dataset across all MPI ranks and reports the
+# AGGREGATE bandwidth (MiB/s) and IOPS. Two access patterns are supported:
+#   * file-per-process (fpp, default) — each rank uses its own file; the
+#     highest-throughput pattern and the easiest for Lustre to stripe.
+#   * single-shared-file (ssf)        — all ranks share one file; stresses
+#     shared-file locking and OST striping.
+#
+# Examples:
+#   # defaults: OpenMPI, POSIX, file-per-process, 2 nodes
+#   sbatch ior.sbatch
+#
+#   # single shared file, MPI-IO, larger transfers
+#   IOR_FILEMODE=ssf IOR_API=MPIIO IOR_TRANSFER=4m sbatch ior.sbatch
+#
+#   # scale out and push more ranks/node
+#   sbatch -N 8 --export=ALL,IOR_TASKS_PER_NODE=16 ior.sbatch
+#
+#   # also run the mdtest metadata benchmark
+#   IOR_MDTEST=1 sbatch ior.sbatch
+#
+# Environment variables (all optional):
+#   IOR_MPI            openmpi | intelmpi          (default openmpi)
+#   IOR_API            POSIX | MPIIO               (default POSIX)
+#   IOR_FILEMODE       fpp | ssf                   (default fpp)
+#   IOR_BLOCK          per-task block size         (default 4g)
+#   IOR_TRANSFER       size of each I/O call       (default 1m)
+#   IOR_SEGMENTS       segments per task           (default 1)
+#   IOR_ITER           iterations (reps)           (default 3)
+#   IOR_TASKS_PER_NODE MPI ranks per node          (default 12)
+#   IOR_DIR            test directory on the FS    (default /fsx/ior-test)
+#   IOR_STRIPE_COUNT   Lustre stripe count (-1=all OSTs)  (default -1)
+#   IOR_STRIPE_SIZE    Lustre stripe size          (default 1M)
+#   IOR_MDTEST         1 to also run mdtest         (default 0)
+#   IOR_EXTRA          extra args appended to ior
+
+set -uo pipefail
+
+IOR_MPI="${IOR_MPI:-openmpi}"
+IOR_API="${IOR_API:-POSIX}"
+IOR_FILEMODE="${IOR_FILEMODE:-fpp}"
+IOR_BLOCK="${IOR_BLOCK:-4g}"
+IOR_TRANSFER="${IOR_TRANSFER:-1m}"
+IOR_SEGMENTS="${IOR_SEGMENTS:-1}"
+IOR_ITER="${IOR_ITER:-3}"
+IOR_TASKS_PER_NODE="${IOR_TASKS_PER_NODE:-12}"
+IOR_DIR="${IOR_DIR:-/fsx/ior-test}"
+IOR_STRIPE_COUNT="${IOR_STRIPE_COUNT:--1}"
+IOR_STRIPE_SIZE="${IOR_STRIPE_SIZE:-1M}"
+IOR_MDTEST="${IOR_MDTEST:-0}"
+IOR_EXTRA="${IOR_EXTRA:-}"
+
+NODES="${SLURM_JOB_NUM_NODES:-1}"
+NTASKS=$(( NODES * IOR_TASKS_PER_NODE ))
+
+# --- Select the MPI stack and the matching IOR install -------------------
+case "${IOR_MPI}" in
+  openmpi)
+    module load openmpi libfabric-aws
+    IOR_HOME="/fsx/IOR-OpenMPI/install"
+    PLACEMENT=(--map-by "ppr:${IOR_TASKS_PER_NODE}:node")
+    ;;
+  intelmpi)
+    module load intelmpi libfabric-aws
+    IOR_HOME="/fsx/IOR-IntelMPI/install"
+    PLACEMENT=(-ppn "${IOR_TASKS_PER_NODE}")
+    ;;
+  *) echo "ERROR: IOR_MPI must be 'openmpi' or 'intelmpi' (got '${IOR_MPI}')" >&2; exit 1 ;;
+esac
+IOR_BIN="${IOR_HOME}/bin/ior"
+MDTEST_BIN="${IOR_HOME}/bin/mdtest"
+if [ ! -x "${IOR_BIN}" ]; then
+  echo "ERROR: ${IOR_BIN} not found — build it first with build_ior_${IOR_MPI}.sh" >&2
+  exit 1
+fi
+
+echo "================================================================================"
+echo "IOR run $(date)"
+echo "  MPI=${IOR_MPI}  API=${IOR_API}  mode=${IOR_FILEMODE}"
+echo "  nodes=${NODES}  tasks/node=${IOR_TASKS_PER_NODE}  total ranks=${NTASKS}"
+echo "  block=${IOR_BLOCK}  transfer=${IOR_TRANSFER}  segments=${IOR_SEGMENTS}  iters=${IOR_ITER}"
+echo "  dir=${IOR_DIR}  stripe_count=${IOR_STRIPE_COUNT}  stripe_size=${IOR_STRIPE_SIZE}"
+echo "================================================================================"
+
+# --- Prepare the test directory and apply a Lustre stripe layout ---------
+# Striping the directory makes every file created under it inherit the layout,
+# spreading I/O across OSTs. -1 stripes across all available OSTs (best for
+# aggregate throughput on FSx for Lustre).
+mkdir -p "${IOR_DIR}"
+if command -v lfs >/dev/null 2>&1; then
+  if lfs setstripe -c "${IOR_STRIPE_COUNT}" -S "${IOR_STRIPE_SIZE}" "${IOR_DIR}" 2>/dev/null; then
+    echo "Lustre stripe layout applied to ${IOR_DIR}:"
+    lfs getstripe -d "${IOR_DIR}" 2>/dev/null | sed 's/^/    /'
+  else
+    echo "WARN: 'lfs setstripe' failed (not Lustre, or no permission); using the directory default layout"
+  fi
+else
+  echo "NOTE: 'lfs' not found — not a Lustre mount; skipping stripe configuration"
+fi
+
+# --- Build the IOR argument list -----------------------------------------
+# -w write, -r read, -e fsync after write (data must reach storage, not just
+# the client page cache), -g barriers between phases, -C reorder tasks so each
+# rank reads a file written by a DIFFERENT node (defeats the client read cache),
+# -i iterations, -b per-task block, -t transfer size, -s segments.
+IOR_ARGS=(-a "${IOR_API}" -b "${IOR_BLOCK}" -t "${IOR_TRANSFER}" -s "${IOR_SEGMENTS}"
+          -w -r -e -g -C -i "${IOR_ITER}" -o "${IOR_DIR}/iorfile")
+if [ "${IOR_FILEMODE}" = "fpp" ]; then
+  IOR_ARGS+=(-F)              # one file per process
+elif [ "${IOR_FILEMODE}" != "ssf" ]; then
+  echo "ERROR: IOR_FILEMODE must be 'fpp' or 'ssf' (got '${IOR_FILEMODE}')" >&2; exit 1
+fi
+# shellcheck disable=SC2206
+[ -n "${IOR_EXTRA}" ] && IOR_ARGS+=(${IOR_EXTRA})
+
+# Aggregate dataset size (informational): ranks x block x segments. For a
+# rigorous cache-defeating read, this should exceed the aggregate client RAM;
+# -C plus the page-cache drop below also mitigate caching.
+echo "Aggregate dataset ~ ${NTASKS} ranks x ${IOR_BLOCK} x ${IOR_SEGMENTS} segments (see the IOR summary for the exact MiB)."
+
+# --- Drop page caches on every node so reads come from the filesystem ----
+echo "==> Dropping page caches on all nodes (best-effort)"
+srun --ntasks="${NODES}" --ntasks-per-node=1 \
+  bash -c 'sync; echo 3 | sudo tee /proc/sys/vm/drop_caches >/dev/null 2>&1 || true'
+
+# --- Run IOR --------------------------------------------------------------
+echo "==> ior ${IOR_ARGS[*]}"
+mpirun -np "${NTASKS}" "${PLACEMENT[@]}" "${IOR_BIN}" "${IOR_ARGS[@]}"
+
+# --- Optional metadata benchmark (mdtest) --------------------------------
+if [ "${IOR_MDTEST}" = "1" ] && [ -x "${MDTEST_BIN}" ]; then
+  echo ""
+  echo "==> mdtest metadata benchmark (create/stat/remove of 0-byte files)"
+  # -n files per rank, -u unique working dir per task, -F files only (no dirs),
+  # -i iterations. Tune -n up for a heavier metadata load.
+  mpirun -np "${NTASKS}" "${PLACEMENT[@]}" \
+    "${MDTEST_BIN}" -n 10000 -u -F -i 2 -d "${IOR_DIR}/mdtest"
+fi
+
+echo ""
+echo "==> Done. Read the 'Max Write' / 'Max Read' (MiB/s) lines in the IOR summary above."


### PR DESCRIPTION
## Summary

Adds **IOR** (https://github.com/hpc/ior), the standard parallel-filesystem benchmark, as a new HPC synthetic benchmark for storage/disk I/O — primarily **Amazon FSx for Lustre**. Follows the existing OSU/HPL utility conventions.

## What's included (`Utils/IOR/`)

- **`build_ior_openmpi.sh` / `build_ior_intelmpi.sh`** — download and build IOR + mdtest 4.0.0 (POSIX + MPI-IO back-ends) to the shared filesystem, one per MPI stack.
- **`ior.sbatch`** — parametric Slurm launcher. Env-var overrides for API (POSIX/MPIIO), file mode (file-per-process / single-shared-file), block/transfer/segment sizes, ranks-per-node, and iterations. FSx for Lustre tuning is baked in:
  - directory striping across all OSTs (`lfs setstripe -c -1`)
  - page-cache drop + `-C` task reorder to defeat client read caching
  - `fsync` on write (`-e`)
  - optional `mdtest` metadata run (`IOR_MDTEST=1`)
- **`README.md`** — build/run guide, parameter reference, FSx for Lustre best practices, and metrics.
- Top-level `README.md` updated to list IOR under *HPC synthetic benchmarks*.

## Testing

- All scripts pass `shellcheck` and `bash -n`.
- Build pinned to the official IOR 4.0.0 release tarball (ships a pre-generated `configure`; no autotools step needed).

> Note: not yet run end-to-end on a live cluster — the launcher defaults target `hpc8a` + `/fsx`. Reviewers with an FSx for Lustre cluster can validate aggregate throughput numbers.